### PR TITLE
[Chore/#8] docker-compose 세팅

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -36,9 +36,13 @@ tasks.named('test') {
 jib {
     from {
         image = "openjdk:11-jre"
+        auth {
+            username = ${DOCKER_ID}
+            password = ${DOCKER_PASSWORD}
+        }
     }
     to {
-        image = "hlhl/jib-rising"
+        image = project.DOCKER_ID + "/" + project.DOCKER_IMAGE_NAME
         tags = ["${project.version}".toString()]
     }
     container {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,8 +5,12 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url:
+      ${MYSQL_URL}
     username:
+      ${MYSQL_USERNAME}
     password:
+      ${MYSQL_PASSWORD}
+
   jpa:
     hibernate:
       ddl-auto: create-drop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+version: "3"
+services:
+  db:
+    container_name: mysql
+    image: mysql:latest
+    #restart: always
+    #volumnes:
+    environment: # 컨테이너 안의 환경변수 설정
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_HOST=localhost
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_USER_PASSWORD}
+      - TZ=Asia/Seoul
+
+    ports:
+      - "3307:3306"
+    tty: true
+    
+#  backend:
+#    container_name: spring_boot
+#    image: ${JIB_IMAGE}
+##    build:
+##      context: .
+#    ports:
+#      - "8080:8080"
+#    depends_on:
+#      - mysql
+#    expose:
+#      - 3306
+##    volumes:
+##      - data_mysql:/mysql
+#    environment:
+#      SPRING_DATASOURCE_URL: ${MYSQL_URL}
+##      SPRING_DATASOURCE_USERNAME: ${MYSQL_USERNAME}
+##      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+#      SPRING_JPA_HIBERNATE_DDL_AUTO: create #운영시는 validate나 none으로 변경
+#    tty: true #명령어 실행 끝나도 꺼지지 않음
+#
+##  frontend:
+#
+#  nginx:
+#    container_name: nginx
+#    image: nginx:latest
+##    build: ./config/nginx
+#    restart: on_failure
+#    volumes:
+#      - static:/home/app/web/static
+#      - media:/home/app/web/media
+#    ports:
+#      - "80:80"
+#
+#
+#
+#networks:
+## 네트워크 설정
+#volumes:
+## 볼륨 설정

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   db:
     container_name: mysql
     image: mysql:latest
-    #restart: always
-    #volumnes:
+    volumes:
+      - ./volume/mysql/data:/var/lib/mysql
     networks:
       - app-tier
     environment: # 컨테이너 안의 환경변수 설정
@@ -30,8 +30,6 @@ services:
       - app-tier
     expose:
       - 3306
-#    volumes:
-#      - data_mysql:/mysql
     environment:
       SPRING_DATASOURCE_URL: ${MYSQL_URL}
       SPRING_DATASOURCE_USERNAME: ${MYSQL_USERNAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,25 +17,25 @@ services:
       - "3307:3306"
     tty: true
     
-#  backend:
-#    container_name: spring_boot
-#    image: ${JIB_IMAGE}
-##    build:
-##      context: .
-#    ports:
-#      - "8080:8080"
-#    depends_on:
-#      - mysql
-#    expose:
-#      - 3306
-##    volumes:
-##      - data_mysql:/mysql
-#    environment:
-#      SPRING_DATASOURCE_URL: ${MYSQL_URL}
-##      SPRING_DATASOURCE_USERNAME: ${MYSQL_USERNAME}
-##      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
-#      SPRING_JPA_HIBERNATE_DDL_AUTO: create #운영시는 validate나 none으로 변경
-#    tty: true #명령어 실행 끝나도 꺼지지 않음
+  backend:
+    container_name: backend_con
+    image: ${JIB_IMAGE}
+#    build:
+#      context: .
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    expose:
+      - 3306
+#    volumes:
+#      - data_mysql:/mysql
+    environment:
+      SPRING_DATASOURCE_URL: ${MYSQL_URL}
+      SPRING_DATASOURCE_USERNAME: ${MYSQL_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+      SPRING_JPA_HIBERNATE_DDL_AUTO: create #운영시는 validate나 none으로 변경
+    tty: true #명령어 실행 끝나도 꺼지지 않음
 #
 ##  frontend:
 #

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,7 +22,7 @@ COPY . ./
 
 # 개발
 # docker-compose.yml 파일에 npm start 작성할거면 지워도 됨
-RUN #npm start
+#RUN npm start
 
 # 배포
 # RUN yarn run build


### PR DESCRIPTION
## 🛠️ 변경사항
- docker-compose로 nginx, backend con, frontend con, mysql 구성
- frontend dockerfile 일부 변경
- mysql만 볼륨 설정


</br>
</br>

## ☝️ 유의사항
- 초기 세팅 방법은 노션 RISING/backend/개발환경 세팅 페이지에 정리해두겠습니다(실행시 .env와 gradle.properties필요)
- 각자의 dockerhub에 backend 이미지가 올라가도록 하려 했으나 현재 하린님이 올려둔 jib 이미지를 사용함. 두 방식이 섞여 있으니 추후 정리할 것
- mysql만 volume 설정된 상태

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
