### PR TITLE
[BE/feat/#75] 채팅메세지 저장 기능 구현

### DIFF
--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatController.java
@@ -22,6 +22,7 @@ public class ChatController {
     @MessageMapping("chat.message.{postId}") // 클라이언트에서 '/pub' 붙여 메세지 보내는 경로
     public void send(@RequestBody MessageDto.ChatMessageDto msg, @DestinationVariable Long postId) {
         rabbitTemplate.convertAndSend(EXCHANGE_NAME, "chat."+ postId, msg); //code.*로 바인딩된 큐로 보냄
+
     }
 
     //메세지가 큐에 도착할 때 실행

--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.rising.backend.domain.chat.controller;
 
+import com.rising.backend.domain.chat.domain.ChatRoom;
 import com.rising.backend.domain.chat.service.ChatRoomService;
 import com.rising.backend.domain.user.domain.User;
 import com.rising.backend.global.annotation.LoginRequired;
@@ -9,10 +10,15 @@ import com.rising.backend.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "CHATROOM API")
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/chatrooms")
@@ -20,13 +26,21 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
+    // 채팅하기 버튼 누르면 채팅방 생성
     @LoginRequired
     @PostMapping("/{postId}")
-    public ResponseEntity<ResultResponse> getSession(
+    public ResponseEntity<ResultResponse> createChatRoom (
             @PathVariable Long postId,
             @Parameter(hidden = true) @LoginUser User loginUser) {
 
-        chatRoomService.createChatRoom(postId);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.CHATROOM_CREATE_SUCCESS));
+        //채팅 신청 기록이 있을 경우 생성 실패
+        if(chatRoomService.isUserChatted(loginUser.getId())) {
+            log.error("이미 채팅 기록이 있음 -> 채팅방으로 리다이렉트시키면 좋을듯");
+            throw new RuntimeException();
+        }
+
+        ChatRoom createdChatRoom = chatRoomService.createChatRoom(postId, loginUser); // loginUser = mentor
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.CHATROOM_CREATE_SUCCESS, createdChatRoom));
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/WebSocketChatController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/WebSocketChatController.java
@@ -16,7 +16,7 @@ import static com.rising.backend.global.constant.RabbitMQ.CHAT_QUEUE_NAME;
 @Controller
 @RequiredArgsConstructor
 @Slf4j
-public class ChatController {
+public class WebSocketChatController {
     private final RabbitTemplate rabbitTemplate;
 
     @MessageMapping("chat.message.{postId}") // 클라이언트에서 '/pub' 붙여 메세지 보내는 경로

--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/WebSocketChatController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/WebSocketChatController.java
@@ -25,14 +25,14 @@ public class WebSocketChatController {
     @MessageMapping("chat.message.{chatRoomId}") // 클라이언트에서 '/pub' 붙여 메세지 보내는 경로
     public void send(@RequestBody MessageDto.ChatMessageDto msg, @DestinationVariable Long chatRoomId) {
 
+        log.info("chatRoomId = {}", chatRoomId);
         rabbitTemplate.convertAndSend(EXCHANGE_NAME, "chat."+ chatRoomId, msg); //code.*로 바인딩된 큐로 보냄
+        chatMessageService.saveChatMessage(msg, chatRoomId);
     }
 
     //메세지가 큐에 도착할 때 실행
     @RabbitListener(queues = CHAT_QUEUE_NAME)
     public void receive(MessageDto.ChatMessageDto msg) {
-
         log.info("message.getText = {}", msg.getContent());
-        chatMessageService.saveChatMessage(msg);
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/WebSocketChatController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/WebSocketChatController.java
@@ -1,6 +1,7 @@
 package com.rising.backend.domain.chat.controller;
 
 import com.rising.backend.domain.chat.dto.MessageDto;
+import com.rising.backend.domain.chat.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -19,15 +20,19 @@ import static com.rising.backend.global.constant.RabbitMQ.CHAT_QUEUE_NAME;
 public class WebSocketChatController {
     private final RabbitTemplate rabbitTemplate;
 
-    @MessageMapping("chat.message.{postId}") // 클라이언트에서 '/pub' 붙여 메세지 보내는 경로
-    public void send(@RequestBody MessageDto.ChatMessageDto msg, @DestinationVariable Long postId) {
-        rabbitTemplate.convertAndSend(EXCHANGE_NAME, "chat."+ postId, msg); //code.*로 바인딩된 큐로 보냄
+    private final ChatMessageService chatMessageService;
 
+    @MessageMapping("chat.message.{chatRoomId}") // 클라이언트에서 '/pub' 붙여 메세지 보내는 경로
+    public void send(@RequestBody MessageDto.ChatMessageDto msg, @DestinationVariable Long chatRoomId) {
+
+        rabbitTemplate.convertAndSend(EXCHANGE_NAME, "chat."+ chatRoomId, msg); //code.*로 바인딩된 큐로 보냄
     }
 
     //메세지가 큐에 도착할 때 실행
     @RabbitListener(queues = CHAT_QUEUE_NAME)
     public void receive(MessageDto.ChatMessageDto msg) {
+
         log.info("message.getText = {}", msg.getContent());
+        chatMessageService.saveChatMessage(msg);
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/domain/ChatMessage.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/domain/ChatMessage.java
@@ -26,4 +26,5 @@ public class ChatMessage {
 
     @CreatedDate
     private LocalDateTime sendDate;
+
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/domain/ChatMessage.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/domain/ChatMessage.java
@@ -1,7 +1,6 @@
 package com.rising.backend.domain.chat.domain;
 
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -23,8 +22,7 @@ public class ChatMessage {
     private String sender;
 
     private String message;
-
-    @CreatedDate
+    
     private LocalDateTime sendDate;
 
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/domain/ChatRoom.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/domain/ChatRoom.java
@@ -1,6 +1,7 @@
 package com.rising.backend.domain.chat.domain;
 
 import com.rising.backend.domain.post.domain.Post;
+import com.rising.backend.domain.user.domain.User;
 import com.rising.backend.global.domain.BaseEntity;
 import lombok.*;
 
@@ -19,5 +20,11 @@ public class ChatRoom extends BaseEntity {
 
     @ManyToOne
     private Post post;
+
+    @ManyToOne
+    private User mentor;
+
+    @ManyToOne
+    private User mentee;
 
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/dto/ChatRoomDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/dto/ChatRoomDto.java
@@ -2,4 +2,6 @@ package com.rising.backend.domain.chat.dto;
 
 public class ChatRoomDto {
 
+
+
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/dto/MessageDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/dto/MessageDto.java
@@ -15,6 +15,5 @@ public class MessageDto {
         private String sender;
 
     }
-
 }
 

--- a/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatMessageMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatMessageMapper.java
@@ -1,0 +1,17 @@
+package com.rising.backend.domain.chat.mapper;
+
+import com.rising.backend.domain.chat.domain.ChatMessage;
+import com.rising.backend.domain.chat.dto.MessageDto;
+
+import static java.time.LocalDateTime.now;
+
+public class ChatMessageMapper {
+    public ChatMessage toChatMessageEntity(MessageDto.ChatMessageDto msgDto) {
+
+        ChatMessage msg = ChatMessage.builder()
+                .chatRoom()
+                .sender(msgDto.getSender())
+                .message(msgDto.getContent())
+                .sendDate(now());
+    }
+}

--- a/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatMessageMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatMessageMapper.java
@@ -1,17 +1,23 @@
 package com.rising.backend.domain.chat.mapper;
 
 import com.rising.backend.domain.chat.domain.ChatMessage;
+import com.rising.backend.domain.chat.domain.ChatRoom;
 import com.rising.backend.domain.chat.dto.MessageDto;
+import org.springframework.stereotype.Component;
 
 import static java.time.LocalDateTime.now;
 
+@Component
 public class ChatMessageMapper {
-    public ChatMessage toChatMessageEntity(MessageDto.ChatMessageDto msgDto) {
+    public ChatMessage toChatMessageEntity(MessageDto.ChatMessageDto msgDto, ChatRoom chatRoom) {
 
         ChatMessage msg = ChatMessage.builder()
-                .chatRoom()
+                .chatRoom(chatRoom)
                 .sender(msgDto.getSender())
                 .message(msgDto.getContent())
-                .sendDate(now());
+                .sendDate(now())
+                .build();
+
+        return msg;
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatRoomMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatRoomMapper.java
@@ -2,6 +2,7 @@ package com.rising.backend.domain.chat.mapper;
 
 import com.rising.backend.domain.chat.domain.ChatRoom;
 import com.rising.backend.domain.post.domain.Post;
+import com.rising.backend.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -9,9 +10,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ChatRoomMapper {
 
-    public ChatRoom toChatRoomEntity(Post post) {
+    public ChatRoom toChatRoomEntity(Post post, User mentor) {
         return ChatRoom.builder()
                 .post(post)
+                .mentor(mentor)
+                .mentee(post.getUser())
                 .build();
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package com.rising.backend.domain.chat.repository;
+
+import com.rising.backend.domain.chat.domain.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/backend/src/main/java/com/rising/backend/domain/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,23 @@
+package com.rising.backend.domain.chat.service;
+
+import com.rising.backend.domain.chat.domain.ChatMessage;
+import com.rising.backend.domain.chat.dto.MessageDto;
+import com.rising.backend.domain.chat.mapper.ChatMessageMapper;
+import com.rising.backend.domain.chat.repository.ChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatMessageRepository chatMessageRepository;;
+
+    private final ChatMessageMapper chatMessageMapper;
+
+
+    public ChatMessage saveChatMessage(MessageDto.ChatMessageDto msgDto) {
+        ChatMessage msg = chatMessageMapper.toChatMessageEntity(msgDto);
+        return chatMessageRepository.save(msg);
+    }
+}

--- a/backend/src/main/java/com/rising/backend/domain/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/service/ChatMessageService.java
@@ -1,9 +1,11 @@
 package com.rising.backend.domain.chat.service;
 
 import com.rising.backend.domain.chat.domain.ChatMessage;
+import com.rising.backend.domain.chat.domain.ChatRoom;
 import com.rising.backend.domain.chat.dto.MessageDto;
 import com.rising.backend.domain.chat.mapper.ChatMessageMapper;
 import com.rising.backend.domain.chat.repository.ChatMessageRepository;
+import com.rising.backend.domain.chat.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,12 +14,15 @@ import org.springframework.stereotype.Service;
 public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;;
+    private final ChatRoomRepository chatRoomRepository;
 
     private final ChatMessageMapper chatMessageMapper;
 
+    public ChatMessage saveChatMessage(MessageDto.ChatMessageDto msgDto, Long chatRoomId) {
 
-    public ChatMessage saveChatMessage(MessageDto.ChatMessageDto msgDto) {
-        ChatMessage msg = chatMessageMapper.toChatMessageEntity(msgDto);
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow();
+        ChatMessage msg = chatMessageMapper.toChatMessageEntity(msgDto, chatRoom);
+
         return chatMessageRepository.save(msg);
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
@@ -3,7 +3,9 @@ package com.rising.backend.domain.chat.service;
 import com.rising.backend.domain.chat.domain.ChatRoom;
 import com.rising.backend.domain.chat.mapper.ChatRoomMapper;
 import com.rising.backend.domain.chat.repository.ChatRoomRepository;
+import com.rising.backend.domain.post.domain.Post;
 import com.rising.backend.domain.post.repository.PostRepository;
+import com.rising.backend.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,9 +17,14 @@ public class ChatRoomService {
     private final ChatRoomMapper chatRoomMapper;
     private final PostRepository postRepository;
 
-    public ChatRoom createChatRoom(Long postId) {
-        return chatRoomRepository.save(chatRoomMapper.toChatRoomEntity(
-                postRepository.findById(postId).orElseThrow()));
+    public ChatRoom createChatRoom(Long postId, User mentor) {
+        Post post = postRepository.findById(postId).orElseThrow();
+
+        return chatRoomRepository.save(chatRoomMapper.toChatRoomEntity(post, mentor));
+    }
+
+    public boolean isUserChatted(Long userId) {
+        return true; // 수정
     }
 
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
@@ -24,7 +24,7 @@ public class ChatRoomService {
     }
 
     public boolean isUserChatted(Long userId) {
-        return true; // 수정
+        return false; // 수정
     }
 
 }

--- a/frontend/src/page/QuesChatPage.tsx
+++ b/frontend/src/page/QuesChatPage.tsx
@@ -60,7 +60,7 @@ function QuesChatPage() {
       },
       onConnect: () => {
         console.log('0 stomp onConnect : ');
-        client.current?.subscribe(`/exchange/rising.exchange/chat.${2}`, handleSub); // '/exchange/exchange명/패턴 code.*') - exchange큐와 code.*로 연결된 큐 구독
+        client.current?.subscribe(`/exchange/rising.exchange/chat.${1}`, handleSub); // '/exchange/exchange명/패턴 code.*') - exchange큐와 code.*로 연결된 큐 구독
       },
       onStompError: (frame) => {
         console.error('1 stomp error : ', frame);
@@ -81,7 +81,7 @@ function QuesChatPage() {
   const handlePub = () => {
     if (!client.current?.connected) return;
     client.current.publish({
-      destination: `/pub/chat.message.${2}`,
+      destination: `/pub/chat.message.${1}`,
       body: JSON.stringify({
         sender: `${sender}`,
         content: `${content}`


### PR DESCRIPTION
## 🛠️ 변경사항

- 채팅 메세지 전송시 db에 저장하는 로직 구현

![image](https://user-images.githubusercontent.com/88549117/212477617-6d3838f5-9dad-4f63-a13a-9fb0a27c2b8b.png)


</br>
</br>

## ☝️ 유의사항

- 프론트에서 임시로 설정해둔 채팅 경로 ${1}로 수정
- 채팅을 건 기록이 있는 유저인지 체크하는 메소드 무조건 false리턴하도록 임시 설정

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
