### PR TITLE
[BE/feat/#72] 채팅 메시지 불러오기 기능 구현

### DIFF
--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatMessageController.java
@@ -1,0 +1,35 @@
+package com.rising.backend.domain.chat.controller;
+
+import com.rising.backend.domain.chat.dto.MessageDto;
+import com.rising.backend.domain.chat.service.ChatMessageService;
+import com.rising.backend.global.result.ResultCode;
+import com.rising.backend.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "CHAT-MESSAGE API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/chatmessages")
+public class ChatMessageController {
+
+    private final ChatMessageService chatMessageService;
+
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<ResultResponse> getMessages(@PathVariable Long chatRoomId,
+                                                      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+        List<MessageDto.ChatMessageListResponse> messages = chatMessageService.getChatMessageList(chatRoomId, pageable);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.CHATMESSAGE_FIND_SUCCESS, messages));
+    }
+
+}

--- a/backend/src/main/java/com/rising/backend/domain/chat/dto/MessageDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/dto/MessageDto.java
@@ -3,6 +3,8 @@ package com.rising.backend.domain.chat.dto;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 public class MessageDto {
 
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -15,5 +17,18 @@ public class MessageDto {
         private String sender;
 
     }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access =  AccessLevel.PRIVATE)
+    @Getter
+    @Builder
+    public static class ChatMessageListResponse {
+
+        private String sender;
+        private String message;
+        private LocalDateTime sendDate;
+
+    }
+
 }
 

--- a/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatMessageMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatMessageMapper.java
@@ -20,4 +20,15 @@ public class ChatMessageMapper {
 
         return msg;
     }
+    public MessageDto.ChatMessageListResponse toChatMessageDto(ChatMessage message) {
+        return MessageDto.ChatMessageListResponse.builder()
+                .sender(message.getSender())
+                .message(message.getMessage())
+                .sendDate(message.getSendDate())
+                .build();
+    }
+    public List<MessageDto.ChatMessageListResponse> toDtoList(List<ChatMessage> messageList) {
+        return messageList.stream().map(p -> toChatMessageDto(p))
+                .collect(Collectors.toList());
+    }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/repository/ChatMessageRepository.java
@@ -1,7 +1,11 @@
 package com.rising.backend.domain.chat.repository;
 
 import com.rising.backend.domain.chat.domain.ChatMessage;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    List<ChatMessage> findByChatRoom_Id(Long chatRoomId, Pageable pageable);
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/service/ChatMessageService.java
@@ -25,4 +25,8 @@ public class ChatMessageService {
 
         return chatMessageRepository.save(msg);
     }
+    public List<MessageDto.ChatMessageListResponse> getChatMessageList(Long chatRoomId, Pageable page) {
+        List<ChatMessage> messages = chatMessageRepository.findByChatRoom_Id(chatRoomId,page);
+        return chatMessageMapper.toDtoList(messages);
+    }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/service/ChatMessageService.java
@@ -7,7 +7,10 @@ import com.rising.backend.domain.chat.mapper.ChatMessageMapper;
 import com.rising.backend.domain.chat.repository.ChatMessageRepository;
 import com.rising.backend.domain.chat.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
+++ b/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
@@ -25,7 +25,8 @@ public enum ResultCode {
     COMMENT_CREATE_SUCCESS(201, "댓글 등록 성공"),
 
     //CHAT
-    CHATROOM_CREATE_SUCCESS(201, "채팅방 생성 성공");
+    CHATROOM_CREATE_SUCCESS(201, "채팅방 생성 성공"),
+    CHATMESSAGE_FIND_SUCCESS(200, "채팅 메시지 반환 성공");
 
     private final int status;
     private final String message;


### PR DESCRIPTION
## 🛠️ 변경사항
- ChattinMessage 리스트 response 값에 사용할 dto 추가 및 이에 따른 mapper추가
- pageable을 이용한 API 컨트롤러에 추가
-  필요한 repository, service 코드 추가

## ☝️ 유의사항

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
