### PR TITLE
[BE/feat/#86] post(게시글)의 키워드 설정 기능 구현

### DIFF
--- a/backend/src/main/java/com/rising/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/controller/PostController.java
@@ -71,8 +71,7 @@ public class PostController {
 
     @GetMapping("/mypages/{userId}")
     public ResponseEntity<ResultResponse> getPostListByUserId(@PathVariable Long userId) {
-        List<PostDto.PostDetailResponse> postList = postService.getPostListByUserId(userId);
+        List<PostDto.PostGetListResponse> postList = postService.getPostListByUserId(userId);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POSTLIST_FIND_BY_USERID_SUCCESS, postList));
-
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/domain/Post.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/domain/Post.java
@@ -7,6 +7,8 @@ import lombok.*;
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -40,4 +42,16 @@ public class Post extends BaseEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     private PostType type;
+
+    @ManyToMany
+    @JoinTable(name = "POST_TAG",
+            joinColumns = @JoinColumn(name = "POST_ID"),
+            inverseJoinColumns = @JoinColumn(name = "TAG_ID")
+    )
+    private List<Tag> tag = new ArrayList<>();
+
+
+    public void setTags(List<Tag> tags) {
+        this.tag = tags;
+    }
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/domain/Tag.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/domain/Tag.java
@@ -1,0 +1,23 @@
+package com.rising.backend.domain.post.domain;
+
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+    private String content;
+
+}
+

--- a/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
@@ -43,6 +43,8 @@ public class PostDto {
 
         @NotEmpty
         private PostType type;
+
+        private List<String> tags;
     }
 
     @Builder

--- a/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
@@ -63,5 +63,7 @@ public class PostDto {
         private String videoUrl;
 
         private PostType type;
+
+        private List<String> tags;
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
@@ -5,6 +5,8 @@ import lombok.*;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PostDto {
 
@@ -22,6 +24,8 @@ public class PostDto {
 
         @NotEmpty
         private PostType type;
+
+        private List<String> tag = new ArrayList<>();
     }
 
     @Builder

--- a/backend/src/main/java/com/rising/backend/domain/post/mapper/PostMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/mapper/PostMapper.java
@@ -8,10 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
-
-import java.util.UUID;
-
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.rising.backend.domain.post.dto.PostDto.PostCreateRequest;
@@ -58,4 +56,5 @@ public class PostMapper {
                 .type(post.getType())
                 .build();
     }
+
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/mapper/PostMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/mapper/PostMapper.java
@@ -56,6 +56,7 @@ public class PostMapper {
                 .content(post.getContent())
                 .title(post.getTitle())
                 .type(post.getType())
+                .tags(TagtoString(post.getTag()))
                 .build();
     }
 

--- a/backend/src/main/java/com/rising/backend/domain/post/mapper/PostMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/mapper/PostMapper.java
@@ -1,6 +1,7 @@
 package com.rising.backend.domain.post.mapper;
 
 import com.rising.backend.domain.post.domain.Post;
+import com.rising.backend.domain.post.domain.Tag;
 import com.rising.backend.domain.post.dto.PostDto;
 import com.rising.backend.domain.user.domain.User;
 import com.rising.backend.global.util.UuidConverter;
@@ -29,13 +30,14 @@ public class PostMapper {
                 .type(postCreate.getType()).build();
     }
 
-    public PostDto.PostDetailResponse toPostDto(Post post) {
+    public PostDto.PostDetailResponse toPostDto(Post post, List<String> tags) {
         return PostDto.PostDetailResponse.builder()
                 .userId(post.getUser().getId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .videoUrl(post.getVideoUrl())
                 .type(post.getType())
+                .tags(tags)
                 .build();
     }
 
@@ -43,8 +45,8 @@ public class PostMapper {
         return studyList.map(this::toPostListResponse);
     }
 
-    public List<PostDto.PostDetailResponse> toDtoList(List<Post> postList) {
-        return postList.stream().map(p -> toPostDto(p))
+    public List<PostDto.PostGetListResponse> toDtoList(List<Post> postList) {
+        return postList.stream().map(p -> toPostListResponse(p))
                 .collect(Collectors.toList());
     }
 
@@ -55,6 +57,11 @@ public class PostMapper {
                 .title(post.getTitle())
                 .type(post.getType())
                 .build();
+    }
+
+    public List<String> TagtoString(List<Tag> tags) {
+        return tags.stream().map(tag -> tag.getContent())
+                .collect(Collectors.toList());
     }
 
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.rising.backend.domain.post.repository;
 
 import com.rising.backend.domain.post.domain.Post;
+import com.rising.backend.domain.post.domain.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +10,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByUserId(Long userId);
 
+    List<Tag> findTagById(Long id);
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/repository/TagRepository.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package com.rising.backend.domain.post.repository;
+
+import com.rising.backend.domain.post.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Tag findByContent(String content);
+
+}

--- a/backend/src/main/java/com/rising/backend/domain/post/repository/TagRepository.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/repository/TagRepository.java
@@ -6,5 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
     Tag findByContent(String content);
-
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/service/PostService.java
@@ -62,10 +62,11 @@ public class PostService {
 
     public PostDto.PostDetailResponse getPostDtoById(Long postId) {
         Post post = findPostById(postId);
-        return postMapper.toPostDto(post);
+        List<String> tags = postMapper.TagtoString(post.getTag());
+        return postMapper.toPostDto(post, tags);
     }
 
-    public List<PostDto.PostDetailResponse> getPostListByUserId(Long userId) {
+    public List<PostDto.PostGetListResponse> getPostListByUserId(Long userId) {
         List<Post> postList = postRepository.findByUserId(userId);
         return postMapper.toDtoList(postList);
     }
@@ -73,4 +74,5 @@ public class PostService {
     public Tag getTagByContent(String content) {
         return tagRepository.findByContent(content);
     }
+
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/service/PostService.java
@@ -1,10 +1,11 @@
 package com.rising.backend.domain.post.service;
 
 import com.rising.backend.domain.post.domain.Post;
+import com.rising.backend.domain.post.domain.Tag;
 import com.rising.backend.domain.post.dto.PostDto;
-
 import com.rising.backend.domain.post.mapper.PostMapper;
 import com.rising.backend.domain.post.repository.PostRepository;
+import com.rising.backend.domain.post.repository.TagRepository;
 import com.rising.backend.domain.user.domain.User;
 import com.rising.backend.global.util.UuidConverter;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.rising.backend.domain.post.dto.PostDto.PostCreateRequest;
 import static com.rising.backend.domain.post.dto.PostDto.PostGetListResponse;
@@ -24,9 +26,14 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostMapper postMapper;
     private final UuidConverter uuidConverter;
+    private final TagRepository tagRepository;
 
     public Post createPost(PostCreateRequest createRequest, User loginUser) {
-        return postRepository.save(postMapper.toPostEntity(createRequest, loginUser));
+        Post postEntity = postMapper.toPostEntity(createRequest, loginUser);
+        List<Tag> tags = createRequest.getTag().stream().map(t -> getTagByContent(t))
+                .collect(Collectors.toList());
+        postEntity.setTags(tags);
+        return postRepository.save(postEntity);
     }
 
     public Post findPostById(Long postId) {
@@ -63,4 +70,7 @@ public class PostService {
         return postMapper.toDtoList(postList);
     }
 
+    public Tag getTagByContent(String content) {
+        return tagRepository.findByContent(content);
+    }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,3 +16,8 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
     generate-ddl: false
+    defer-datasource-initialization: true
+
+  sql:
+    init:
+      mode: always

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,0 +1,1 @@
+INSERT INTO risingdb.tag (content) VALUES ('Java'), ('Python'), ('JavaScript'), ('TypeScript'), ('Spring'), ('React');

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,1 +1,3 @@
-INSERT INTO risingdb.tag (content) VALUES ('Java'), ('Python'), ('JavaScript'), ('TypeScript'), ('Spring'), ('React');
+INSERT IGNORE INTO risingdb.tag (id, content) VALUES (1, 'Java'), (2, 'Python'), (3, 'JavaScript'), (4, 'TypeScript'), (5, 'Spring'), (6, 'React');
+
+


### PR DESCRIPTION
## 🛠️ 변경사항
- 미리 설정해 놓은 키워드 데이터 삽입을 위한 query가 작성된 data.sql 파일 추가
- 이에 따른 application.yml 설정 추가
- Post와 Tag 엔티티의 다대다 연관관계를 위한 조인 테이블(Post_Tag) 생성을 위한 설정 Post 엔티티에 추가
- Tag 엔티티 생성
- 이에 따른 repository, service, controller 로직 추가

</br>
</br>

## ☝️ 유의사항

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
