### PR TITLE
feat: 댓글과 대댓글 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/rising/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/controller/CommentController.java
@@ -11,17 +11,15 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "COMMENT API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/comments")
 public class CommentController {
-
     private final CommentService commentService;
     @PostMapping
     @LoginRequired
@@ -29,5 +27,11 @@ public class CommentController {
                                                  @Parameter(hidden = true) @LoginUser User loginUser) {
         commentService.createComment(createRequest, loginUser.getId());
         return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_CREATE_SUCCESS));
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<ResultResponse> getComments(@RequestParam Long postId) {
+        List<CommentDto.CommentListResponse> comments = commentService.findByPostId(postId);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_CREATE_SUCCESS, comments));
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/dto/CommentDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/dto/CommentDto.java
@@ -1,11 +1,11 @@
 package com.rising.backend.domain.comment.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class CommentDto {
 
@@ -20,5 +20,20 @@ public class CommentDto {
         private String content;
 
         private Long parentId = null;
+    }
+
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access =  AccessLevel.PRIVATE)
+    @Getter
+    public static class CommentListResponse {
+
+        private String content;
+
+        private String user;
+
+        private List<CommentListResponse> children = new ArrayList<>();
+
+        private LocalDateTime createdAt;
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/mapper/CommentMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/mapper/CommentMapper.java
@@ -2,19 +2,19 @@ package com.rising.backend.domain.comment.mapper;
 
 import com.rising.backend.domain.comment.domain.Comment;
 import com.rising.backend.domain.comment.dto.CommentDto;
-import com.rising.backend.domain.comment.repository.CommentRepository;
 import com.rising.backend.domain.post.service.PostService;
 import com.rising.backend.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class CommentMapper {
-
-    private final CommentRepository commentRepository;
     private final UserService userService;
     private final PostService postService;
+
 
     public Comment toCommentEntity(CommentDto.CommentCreateRequest commentCreate, Long userId) {
         return Comment.builder()
@@ -24,5 +24,16 @@ public class CommentMapper {
                 .parentId(commentCreate.getParentId())
                 .build();
     }
+
+    public CommentDto.CommentListResponse toCommentDto(Comment comment,
+                                                       List<CommentDto.CommentListResponse> children) {
+        return CommentDto.CommentListResponse.builder()
+                .user(comment.getUser().getName())
+                .children(children)
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
 
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/repository/CommentRepository.java
@@ -2,7 +2,17 @@ package com.rising.backend.domain.comment.repository;
 
 import com.rising.backend.domain.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    @Query("SELECT c FROM Comment c WHERE c.parentId is null and c.post.id = ?1 ORDER BY c.createdAt ASC")
+    List<Comment> findCommentsByPostId(Long postId);
+
+    @Query("SELECT c FROM Comment c WHERE c.parentId = ?1 ORDER BY c.createdAt ASC")
+    List<Comment> findChildrenComments(Long parentId);
+
+    List<Comment> findByParentId(Long parentId);
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/service/CommentService.java
@@ -7,6 +7,9 @@ import com.rising.backend.domain.comment.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class CommentService {
@@ -16,5 +19,17 @@ public class CommentService {
     public Comment createComment(CommentDto.CommentCreateRequest dto, Long userId) {
         Comment entity = commentMapper.toCommentEntity(dto, userId);
         return commentRepository.save(entity);
+    }
+
+    public List<CommentDto.CommentListResponse> findByPostId(Long postId) {
+        List<Comment> comments = commentRepository.findCommentsByPostId(postId);
+        return comments.stream().map(c -> commentMapper.toCommentDto(c, findChildrenByParentId(c.getId())))
+                .collect(Collectors.toList());
+    }
+
+    public List<CommentDto.CommentListResponse> findChildrenByParentId(Long parentId) {
+        List<Comment> comments = commentRepository.findByParentId(parentId);
+        return comments.stream().map(c -> commentMapper.toCommentDto(c, null))
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
@@ -25,7 +25,7 @@ public class PostDto {
         @NotEmpty
         private PostType type;
 
-        private List<String> tag = new ArrayList<>();
+        private List<String> tags = new ArrayList<>();
     }
 
     @Builder

--- a/backend/src/main/java/com/rising/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/service/PostService.java
@@ -30,7 +30,7 @@ public class PostService {
 
     public Post createPost(PostCreateRequest createRequest, User loginUser) {
         Post postEntity = postMapper.toPostEntity(createRequest, loginUser);
-        List<Tag> tags = createRequest.getTag().stream().map(t -> getTagByContent(t))
+        List<Tag> tags = createRequest.getTags().stream().map(t -> getTagByContent(t))
                 .collect(Collectors.toList());
         postEntity.setTags(tags);
         return postRepository.save(postEntity);

--- a/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
+++ b/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
@@ -24,6 +24,7 @@ public enum ResultCode {
 
     //COMMENT
     COMMENT_CREATE_SUCCESS(201, "댓글 등록 성공"),
+    COMMENT_GET_SUCCESS(200, "댓글 조회 성공"),
 
     //CHAT
     CHATROOM_CREATE_SUCCESS(201, "채팅방 생성 성공"),


### PR DESCRIPTION
## 🛠️ 변경사항
- Tag 관련 Dto의 변수명 'tags'로 통일
- CommentRepostiory에 부모 댓글과 대댓글 조회하는 함수 작성 -> @Query 이용
- 기능 구현을 위한 controller, service, mapper에 관련 코드 추가
</br>
![image](https://user-images.githubusercontent.com/75435113/212701109-99ebf45a-28af-4ed2-bc6e-9b23cbcafe8d.png)

</br>
</br>

## ☝️ 유의사항

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
