### PR TITLE
[FE/feat/#98] 일반 질문 페이지 api 연동 구현

### DIFF
--- a/frontend/src/page/PrivateQuesPage.tsx
+++ b/frontend/src/page/PrivateQuesPage.tsx
@@ -15,7 +15,7 @@ interface privateQuesForm {
   type: string;
   title: string;
   tags: string[];
-  content: string | null;
+  content: string;
 }
 
 // 질문 작성 페이지
@@ -41,7 +41,7 @@ function PrivateQuesPage() {
     console.log(privateQuesData);
     (async () => {
       await axios
-        .post(`/posts`, privateQuesData, {
+        .post('/posts', privateQuesData, {
           headers: {
             'Content-Type': 'application/json',
           },

--- a/frontend/src/page/PrivateQuesPage.tsx
+++ b/frontend/src/page/PrivateQuesPage.tsx
@@ -15,7 +15,7 @@ interface privateQuesForm {
   type: string;
   title: string;
   tags: string[];
-  content: string;
+  content: string | null;
 }
 
 // 질문 작성 페이지

--- a/frontend/src/page/QuesPage.tsx
+++ b/frontend/src/page/QuesPage.tsx
@@ -35,7 +35,7 @@ function QuesPage() {
   console.log(QuesData);
   (async () => {
     await axios
-      .post('http://localhost:8080/api/v1/posts', QuesData, {
+      .post('/posts', QuesData, {
         headers: {
           'Content-Type': 'application/json',
         },

--- a/frontend/src/page/QuesPage.tsx
+++ b/frontend/src/page/QuesPage.tsx
@@ -1,20 +1,63 @@
 import 'tailwindcss/tailwind.css';
 import 'utils/pageStyle.css';
+import { useState } from 'react';
 import ColorSystem from 'utils/ColorSystem';
 import { useNavigate } from 'react-router-dom';
 import QuesNavBar from 'components/NavBar/QuesNavBar';
 import KeywordSelect from 'components/Select/KeywordSelect';
-import Btn from 'components/Btn';
 import TitleIndex from 'components/Index/QuesTitleIndex';
 import ContentIndex from 'components/Index/EndIndex';
 import KeywordIndex from 'components/Index/KeywordIndex';
+import axios from 'axios';
 
+interface QuesForm {
+  type: string;
+  title: string;
+  tags: string[];
+  content: string;
+}
 // 질문 작성 페이지
 function QuesPage() {
+
   const navigate = useNavigate();
-  const goToMain = () => {
-    navigate('/mainpage');
+  const [titletext, setTitletext] = useState('');
+  const [keyWord, setKeyWord] = useState([]);
+  const [text, setText] = useState('');
+
+  const handleSubmit = (e: any) => {
+  e.preventDefault();
+  const QuesData: QuesForm = {
+    type: 'QUESTION',
+    title: titletext,
+    tags: keyWord,
+    content: text,
   };
+  console.log(QuesData);
+  (async () => {
+    await axios
+      .post('http://localhost:8080/api/v1/posts', QuesData, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+      .then((res) => {
+        navigate('/mainpage');
+        console.log(res.data);
+        console.log(keyWord);
+      })
+      .catch((error) => {
+        console.log(error.response.data);
+      });
+  })();
+};
+
+  const onChangeKeyWord = async (e: any) => {
+    const keyWordList: any = e;
+    const result: any = keyWordList.map((data: any) => data.value);
+    setKeyWord(result);
+  };
+
+
   return (
     // 배경색
     <div
@@ -23,6 +66,7 @@ function QuesPage() {
     >
       {/* 상단바 */}
       <QuesNavBar />
+      <form onSubmit={handleSubmit}>
       {/* Title */}
       <div className="flex justify-center item-center my-8">
         <div className="relative flex flex-col-reverse w-3/5">
@@ -33,6 +77,9 @@ function QuesPage() {
                 type="text"
                 className="absolute top-1 left-2 w-full h-10 rounded-lg focus:shadow focus:outline-none"
                 placeholder="Title.."
+                onChange={(e) => {
+                  setTitletext(e.target.value);
+                }}
               />
             </div>
           </div>
@@ -45,7 +92,9 @@ function QuesPage() {
       <div className="flex justify-center item-center my-8">
         <div className="relative flex flex-col-reverse w-3/5">
           <div className="flex flex-col rounded-xl h-14 w-full mx-1 my-2 bg-white border-4 border-violet-300">
-            {/* 키워드 작성 */}
+              <div className="pt-1 px-1">
+                <KeywordSelect onChange={onChangeKeyWord} />
+              </div>
             <div className="pt-1 px-1">{/* <KeywordSelect /> */}</div>
           </div>
           {/* keyword index */}
@@ -63,6 +112,9 @@ function QuesPage() {
                 type="text"
                 className="absolute top-1 left-2 w-full h-10 rounded-lg focus:shadow focus:outline-none"
                 placeholder="Content.."
+                onChange={(e) => {
+                  setText(e.target.value);
+                }}
               />
             </div>
           </div>
@@ -72,14 +124,15 @@ function QuesPage() {
         </div>
       </div>
       {/* Submit */}
-      <div className="flex justify-center item-center my-8">
-        <button
-          type="submit"
-          className="h-8 w-20 rounded-lg bg-violet-200 hover:bg-violet-300"
-        >
-          <span className="text-white text-sm">SUBMIT</span>
-        </button>
-      </div>
+        <div className="flex justify-center item-center my-8">
+          <button
+            type="submit"
+            className="h-8 w-20 rounded-lg bg-violet-200 hover:bg-violet-300"
+          >
+            <span className="text-white text-sm">SUBMIT</span>
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/frontend/src/page/QuesPage.tsx
+++ b/frontend/src/page/QuesPage.tsx
@@ -1,6 +1,6 @@
 import 'tailwindcss/tailwind.css';
 import 'utils/pageStyle.css';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import ColorSystem from 'utils/ColorSystem';
 import { useNavigate } from 'react-router-dom';
 import QuesNavBar from 'components/NavBar/QuesNavBar';
@@ -8,17 +8,19 @@ import KeywordSelect from 'components/Select/KeywordSelect';
 import TitleIndex from 'components/Index/QuesTitleIndex';
 import ContentIndex from 'components/Index/EndIndex';
 import KeywordIndex from 'components/Index/KeywordIndex';
+import ToastEditor from 'components/Editor/ToastEditor';
 import axios from 'axios';
 
 interface QuesForm {
   type: string;
   title: string;
   tags: string[];
-  content: string;
+  content: string | null ;
 }
 // 질문 작성 페이지
 function QuesPage() {
 
+  const ref = useRef<any>(null);
   const navigate = useNavigate();
   const [titletext, setTitletext] = useState('');
   const [keyWord, setKeyWord] = useState([]);
@@ -26,11 +28,14 @@ function QuesPage() {
 
   const handleSubmit = (e: any) => {
   e.preventDefault();
+  const editorIns = ref?.current?.getInstance();
+  // 에디터 작성 내용 markdown으로 저장
+  const contentMark = editorIns.getMarkdown();
   const QuesData: QuesForm = {
     type: 'QUESTION',
     title: titletext,
     tags: keyWord,
-    content: text,
+    content: contentMark,
   };
   console.log(QuesData);
   (async () => {
@@ -105,9 +110,10 @@ function QuesPage() {
       {/* Content */}
       <div className="flex justify-center item-center my-8">
         <div className="relative flex flex-col-reverse w-3/5">
-          <div className="flex flex-col rounded-xl h-64 w-full pr-4 mx-1 my-2 bg-white border-4 border-violet-300">
-            {/* 질문할 내용 작성 */}
-            <div className="relative">
+          <div className="flex flex-col rounded-xl h-[20rem] w-full mx-1 my-2 pt-1.5 px-1 bg-white border-4 border-violet-300">
+              {/* 텍스트 편집기 */}
+              <ToastEditor editorRef={ref} />
+            {/* <div className="relative">
               <input
                 type="text"
                 className="absolute top-1 left-2 w-full h-10 rounded-lg focus:shadow focus:outline-none"
@@ -116,7 +122,7 @@ function QuesPage() {
                   setText(e.target.value);
                 }}
               />
-            </div>
+            </div> */}
           </div>
           {/* Record video index */}
           <ContentIndex />


### PR DESCRIPTION
## 🛠️ 변경사항
<과외 질문 페이지> api 연동 코드 참고하여 
<일반 질문 페이지> api 연동 완료
</br>
</br>

## ☝️ 유의사항
<일반 질문 등록 페이지> content 입력창 크기 퍼블리싱 수정하기 추후에 진행
<일반 질문 등록 페이지> 또한 <과외 질문 등록 페이지> 에서 Title, Keyword, Content 입력 안했을 때 alert 경고 알림 띄우기 구현 추후에 진행 
</br>
</br>

## ❗체크리스트
- [ ] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [ ] 수정 가능하도록 유연하게 작성했나요?
- [ ] 필요 없는 import문이나 setter 등을 삭제했나요?
- [ ] 기존의 코드에 영향이 없는 것을 확인하였나요?
