### PR TITLE
[BE/feat/#105] 로그인된 유저가 멘티인 채팅방 불러오기 api 구현

### DIFF
--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
@@ -48,6 +48,7 @@ public class ChatRoomController {
     }
 
 
+    // 현재 로그인된 user가 mentee인 채팅방 조회
     @LoginRequired
     @PostMapping("/mentee")
     public ResponseEntity<ResultResponse> findMenteeChatRoom (

--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.rising.backend.domain.chat.controller;
 
 import com.rising.backend.domain.chat.domain.ChatRoom;
+import com.rising.backend.domain.chat.dto.ChatRoomDto;
 import com.rising.backend.domain.chat.service.ChatRoomService;
 import com.rising.backend.domain.user.domain.User;
 import com.rising.backend.global.annotation.LoginRequired;
@@ -16,6 +17,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "CHATROOM API")
 @Slf4j
@@ -42,5 +45,16 @@ public class ChatRoomController {
         ChatRoom createdChatRoom = chatRoomService.createChatRoom(postId, loginUser); // loginUser = mentor
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.CHATROOM_CREATE_SUCCESS, createdChatRoom));
+    }
+
+
+    @LoginRequired
+    @PostMapping("/mentee")
+    public ResponseEntity<ResultResponse> findMenteeChatRoom (
+            @Parameter(hidden = true) @LoginUser User loginUser) {
+
+        List<ChatRoomDto.ChatRoomResponse> menteeChatRoom = chatRoomService.findMenteeChatRoom(loginUser.getId());
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.CHATROOM_FIND_BY_MENTEE, menteeChatRoom));
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
@@ -13,10 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -50,7 +47,7 @@ public class ChatRoomController {
 
     // 현재 로그인된 user가 mentee인 채팅방 조회
     @LoginRequired
-    @PostMapping("/mentee")
+    @GetMapping("/mentee")
     public ResponseEntity<ResultResponse> findMenteeChatRoom (
             @Parameter(hidden = true) @LoginUser User loginUser) {
 

--- a/backend/src/main/java/com/rising/backend/domain/chat/dto/ChatRoomDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/dto/ChatRoomDto.java
@@ -1,13 +1,10 @@
 package com.rising.backend.domain.chat.dto;
 
 import com.rising.backend.domain.post.dto.PostDto;
-import com.rising.backend.domain.user.domain.User;
 import com.rising.backend.domain.user.dto.UserDto;
 import lombok.*;
 
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 
 public class ChatRoomDto {
 

--- a/backend/src/main/java/com/rising/backend/domain/chat/dto/ChatRoomDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/dto/ChatRoomDto.java
@@ -6,6 +6,7 @@ import com.rising.backend.domain.user.dto.UserDto;
 import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public class ChatRoomDto {
@@ -16,13 +17,16 @@ public class ChatRoomDto {
     @Builder
     public static class ChatRoomResponse {
 
-        @NotEmpty
+        @NotNull
         Long roomId;
 
+        @NotNull
         UserDto.UserChatRoomResponse mentee;
 
+        @NotNull
         UserDto.UserChatRoomResponse mentor;
 
+        @NotNull
         PostDto.PostChatRoomResponse post;
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/dto/ChatRoomDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/dto/ChatRoomDto.java
@@ -1,7 +1,28 @@
 package com.rising.backend.domain.chat.dto;
 
+import com.rising.backend.domain.post.dto.PostDto;
+import com.rising.backend.domain.user.domain.User;
+import com.rising.backend.domain.user.dto.UserDto;
+import lombok.*;
+
+import javax.validation.constraints.NotEmpty;
+import java.time.LocalDateTime;
+
 public class ChatRoomDto {
 
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access =  AccessLevel.PRIVATE)
+    @Getter
+    @Builder
+    public static class ChatRoomResponse {
 
+        @NotEmpty
+        Long roomId;
 
+        UserDto.UserChatRoomResponse mentee;
+
+        UserDto.UserChatRoomResponse mentor;
+
+        PostDto.PostChatRoomResponse post;
+    }
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatRoomMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatRoomMapper.java
@@ -32,7 +32,7 @@ public class ChatRoomMapper {
                 .roomId(chatRoom.getId())
                 .mentee(userMapper.toUserDto(chatRoom.getMentee()))
                 .mentor(userMapper.toUserDto(chatRoom.getMentor()))
-                .post(postMapper.toPostChatRoomResponse(chatRoom.getPost()))
+                .post(postMapper.toChatRoomPostDto(chatRoom.getPost()))
                 .build();
     }
     public List<ChatRoomDto.ChatRoomResponse> toChatRoomDtoList(List<ChatRoom> chatRooms) {

--- a/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatRoomMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/mapper/ChatRoomMapper.java
@@ -1,14 +1,23 @@
 package com.rising.backend.domain.chat.mapper;
 
 import com.rising.backend.domain.chat.domain.ChatRoom;
+import com.rising.backend.domain.chat.dto.ChatRoomDto;
 import com.rising.backend.domain.post.domain.Post;
+import com.rising.backend.domain.post.mapper.PostMapper;
 import com.rising.backend.domain.user.domain.User;
+import com.rising.backend.domain.user.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class ChatRoomMapper {
+
+    private final UserMapper userMapper;
+    private final PostMapper postMapper;
 
     public ChatRoom toChatRoomEntity(Post post, User mentor) {
         return ChatRoom.builder()
@@ -17,4 +26,18 @@ public class ChatRoomMapper {
                 .mentee(post.getUser())
                 .build();
     }
+
+    public ChatRoomDto.ChatRoomResponse toChatRoomDto (ChatRoom chatRoom) {
+        return ChatRoomDto.ChatRoomResponse.builder()
+                .roomId(chatRoom.getId())
+                .mentee(userMapper.toUserDto(chatRoom.getMentee()))
+                .mentor(userMapper.toUserDto(chatRoom.getMentor()))
+                .post(postMapper.toPostChatRoomResponse(chatRoom.getPost()))
+                .build();
+    }
+    public List<ChatRoomDto.ChatRoomResponse> toChatRoomDtoList(List<ChatRoom> chatRooms) {
+        return chatRooms.stream().map(r -> toChatRoomDto(r))
+                .collect(Collectors.toList());
+    }
+
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/repository/ChatRoomRepository.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/repository/ChatRoomRepository.java
@@ -3,5 +3,8 @@ package com.rising.backend.domain.chat.repository;
 import com.rising.backend.domain.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    List<ChatRoom> findByMentee_Id(Long id);
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
@@ -1,21 +1,26 @@
 package com.rising.backend.domain.chat.service;
 
 import com.rising.backend.domain.chat.domain.ChatRoom;
+import com.rising.backend.domain.chat.dto.ChatRoomDto;
 import com.rising.backend.domain.chat.mapper.ChatRoomMapper;
 import com.rising.backend.domain.chat.repository.ChatRoomRepository;
 import com.rising.backend.domain.post.domain.Post;
 import com.rising.backend.domain.post.repository.PostRepository;
 import com.rising.backend.domain.user.domain.User;
+import com.rising.backend.domain.user.dto.UserDto;
+import com.rising.backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
-    private final ChatRoomMapper chatRoomMapper;
     private final PostRepository postRepository;
+    private final ChatRoomMapper chatRoomMapper;
 
     public ChatRoom createChatRoom(Long postId, User mentor) {
         Post post = postRepository.findById(postId).orElseThrow();
@@ -23,6 +28,12 @@ public class ChatRoomService {
         return chatRoomRepository.save(chatRoomMapper.toChatRoomEntity(post, mentor));
     }
 
+    public List<ChatRoomDto.ChatRoomResponse> findMenteeChatRoom(Long menteeId) {
+
+        List<ChatRoom> chatRooms = chatRoomRepository.findByMentee_Id(menteeId);
+        List<ChatRoomDto.ChatRoomResponse> chatRoomsDto = chatRoomMapper.toMenteeChatRoomEntity(chatRooms);
+        return chatRoomsDto;
+    }
     public boolean isUserChatted(Long userId) {
         return false; // 수정
     }

--- a/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
@@ -29,9 +29,8 @@ public class ChatRoomService {
     }
 
     public List<ChatRoomDto.ChatRoomResponse> findMenteeChatRoom(Long menteeId) {
-
         List<ChatRoom> chatRooms = chatRoomRepository.findByMentee_Id(menteeId);
-        List<ChatRoomDto.ChatRoomResponse> chatRoomsDto = chatRoomMapper.toMenteeChatRoomEntity(chatRooms);
+        List<ChatRoomDto.ChatRoomResponse> chatRoomsDto = chatRoomMapper.toChatRoomDtoList(chatRooms);
         return chatRoomsDto;
     }
     public boolean isUserChatted(Long userId) {

--- a/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
@@ -7,8 +7,6 @@ import com.rising.backend.domain.chat.repository.ChatRoomRepository;
 import com.rising.backend.domain.post.domain.Post;
 import com.rising.backend.domain.post.repository.PostRepository;
 import com.rising.backend.domain.user.domain.User;
-import com.rising.backend.domain.user.dto.UserDto;
-import com.rising.backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -84,10 +85,10 @@ public class PostDto {
     @Getter
     public static class PostChatRoomResponse {
 
-        @NotEmpty
+        @NotNull
         private Long postId;
 
-        @NotEmpty
+        @NotNull
         private Long userId; //작성자
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/dto/PostDto.java
@@ -77,4 +77,17 @@ public class PostDto {
 
         private List<String> tags;
     }
+
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access =  AccessLevel.PRIVATE)
+    @Getter
+    public static class PostChatRoomResponse {
+
+        @NotEmpty
+        private Long postId;
+
+        @NotEmpty
+        private Long userId; //작성자
+    }
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/mapper/PostMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/mapper/PostMapper.java
@@ -45,6 +45,14 @@ public class PostMapper {
                 .build();
     }
 
+    //ChatRoom 조회시 보이는 Post정보
+    public PostDto.PostChatRoomResponse toPostChatRoomResponse(Post post) {
+        return PostDto.PostChatRoomResponse.builder()
+                .postId(post.getId())
+                .userId(post.getUser().getId())
+                .build();
+    }
+
     public Page<PostGetListResponse> toDtoPageList(Page<Post> studyList) {
         return studyList.map(this::toPostListResponse);
     }

--- a/backend/src/main/java/com/rising/backend/domain/post/mapper/PostMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/mapper/PostMapper.java
@@ -46,7 +46,7 @@ public class PostMapper {
     }
 
     //ChatRoom 조회시 보이는 Post정보
-    public PostDto.PostChatRoomResponse toPostChatRoomResponse(Post post) {
+    public PostDto.PostChatRoomResponse toChatRoomPostDto(Post post) {
         return PostDto.PostChatRoomResponse.builder()
                 .postId(post.getId())
                 .userId(post.getUser().getId())

--- a/backend/src/main/java/com/rising/backend/domain/user/dto/UserDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/dto/UserDto.java
@@ -37,4 +37,19 @@ public class UserDto {
         @NotEmpty
         private String password;
     }
+
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    public static class UserChatRoomResponse {
+
+        @NotEmpty
+        private Long userId;
+
+        @NotEmpty
+        private String name;
+
+        private String profileUrl;
+    }
 }

--- a/backend/src/main/java/com/rising/backend/domain/user/dto/UserDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/dto/UserDto.java
@@ -4,6 +4,7 @@ import lombok.*;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 @Getter
 public class UserDto {
@@ -44,7 +45,7 @@ public class UserDto {
     @Getter
     public static class UserChatRoomResponse {
 
-        @NotEmpty
+        @NotNull
         private Long userId;
 
         @NotEmpty

--- a/backend/src/main/java/com/rising/backend/domain/user/mapper/UserMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/mapper/UserMapper.java
@@ -20,4 +20,13 @@ public class UserMapper {
                 .profileUrl("")
                 .build();
     }
+
+    //채팅방 조회시 보이는 user 정보
+    public UserDto.UserChatRoomResponse toUserDto(User user) {
+        return UserDto.UserChatRoomResponse.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .profileUrl(user.getProfileUrl())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
+++ b/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
@@ -26,8 +26,14 @@ public enum ResultCode {
     COMMENT_CREATE_SUCCESS(201, "댓글 등록 성공"),
     COMMENT_GET_SUCCESS(200, "댓글 조회 성공"),
 
-    //CHAT
+    //CHATROOM
     CHATROOM_CREATE_SUCCESS(201, "채팅방 생성 성공"),
+    CHATROOM_FIND_BY_MENTEE(200, "로그인된 유저가 멘티인 채팅방 조회 성공"),
+    CHATROOM_FIND_BY_MENTOR(200, "로그인된 유저가 멘토인 채팅방 조회 성공"),
+
+
+
+    //CHATMESSAGE
     CHATMESSAGE_FIND_SUCCESS(200, "채팅 메시지 반환 성공");
 
     private final int status;

--- a/backend/src/main/java/test.java
+++ b/backend/src/main/java/test.java
@@ -1,3 +1,0 @@
-public class test {
-    
-}


### PR DESCRIPTION
## 🛠️ 변경사항

/api/v1/chatrooms/mentee
로그인된 유저가 멘티인 채팅방 불러오기 api 구현

![image](https://user-images.githubusercontent.com/88549117/213142604-f9c78a40-f13b-4974-be80-56210f9fae99.png)


</br>
</br>

## ☝️ 유의사항

- 현재 request cookie가 보내지지 않는 오류가 있으므로 로그인 + 테스트를 postman에서 진행함

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
