### PR TITLE
[BE/fix/#112] comment get API response 수정

### DIFF
--- a/backend/src/main/java/com/rising/backend/domain/comment/dto/CommentDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/dto/CommentDto.java
@@ -1,9 +1,11 @@
 package com.rising.backend.domain.comment.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +36,9 @@ public class CommentDto {
 
         private List<CommentListResponse> children = new ArrayList<>();
 
-        private LocalDateTime createdAt;
+        private LocalDate createdDate;
+
+        @JsonFormat(pattern = "HH:mm:ss")
+        private LocalTime createdTime;
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/mapper/CommentMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/mapper/CommentMapper.java
@@ -31,9 +31,8 @@ public class CommentMapper {
                 .user(comment.getUser().getName())
                 .children(children)
                 .content(comment.getContent())
-                .createdAt(comment.getCreatedAt())
+                .createdDate(comment.getCreatedAt().toLocalDate())
+                .createdTime(comment.getCreatedAt().toLocalTime())
                 .build();
     }
-
-
 }


### PR DESCRIPTION
## 🛠️ 변경사항
- commentDto의 CommentListResponse 변수 중 LocalDateTime 타입 변수를 Localtime, LocalDate로 분리
</br>
</br>

## ☝️ 유의사항

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
