### PR TITLE
feat: user 정보 조회 (마이페이지) api

### DIFF
--- a/backend/src/main/java/com/rising/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/controller/UserController.java
@@ -6,6 +6,9 @@ import com.rising.backend.domain.user.dto.UserDto;
 import com.rising.backend.domain.user.service.LoginService;
 import com.rising.backend.domain.user.service.UserService;
 import com.rising.backend.global.annotation.LoginRequired;
+import com.rising.backend.global.annotation.LoginUser;
+import com.rising.backend.global.result.ResultCode;
+import com.rising.backend.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -65,5 +68,14 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body("로그아웃 성공");
     }
+
+    @GetMapping("/info")
+    @LoginRequired
+    public ResponseEntity<ResultResponse> userInfo(@LoginUser User user) {
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_FIND_INFO_SUCCESS,userService.getUserInfo(user)));
+    }
+
+
 
 }

--- a/backend/src/main/java/com/rising/backend/domain/user/dto/UserDto.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/dto/UserDto.java
@@ -53,4 +53,26 @@ public class UserDto {
 
         private String profileUrl;
     }
+
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    public static class UserInfoResponse {
+
+        @NotNull
+        private Long userId;
+
+        @NotEmpty
+        private String userName;
+
+        @NotEmpty
+        private String name;
+
+        private String profileUrl;
+
+
+    }
+
+
 }

--- a/backend/src/main/java/com/rising/backend/domain/user/mapper/UserMapper.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/mapper/UserMapper.java
@@ -29,4 +29,13 @@ public class UserMapper {
                 .profileUrl(user.getProfileUrl())
                 .build();
     }
+
+    public UserDto.UserInfoResponse toUserInfoDto(User user) {
+        return UserDto.UserInfoResponse.builder()
+                .userId(user.getId())
+                .userName(user.getUsername())
+                .name(user.getName())
+                .profileUrl(user.getProfileUrl())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/rising/backend/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
     Optional<User> findByUsername(String username);
+
 }

--- a/backend/src/main/java/com/rising/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/service/UserService.java
@@ -34,4 +34,8 @@ public class UserService {
         return userRepository.findByUsername(username).orElseThrow(() ->
                 new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
     }
+
+    public UserDto.UserInfoResponse getUserInfo(User user) {
+        return userMapper.toUserInfoDto(user);
+    }
 }

--- a/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
+++ b/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
@@ -10,6 +10,7 @@ public enum ResultCode {
     //USER
     USER_NOT_LOGIN(201, "로그인 필요"),
     USER_LOGIN_SUCCESS(200, "로그인 성공"),
+    USER_FIND_INFO_SUCCESS(200, "유저 정보 조회 성공"),
 
     //POST
     POST_CREATE_SUCCESS(201, "게시글 등록 성공"),


### PR DESCRIPTION
## 🛠️ 변경사항

- 현재 로그인된 유저의 정보 조회 api 구현
- 
![image](https://user-images.githubusercontent.com/88549117/213646029-d2956960-5785-4566-8b3d-d43ebbd7ab1d.png)


</br>
</br>

## ☝️ 유의사항

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
