### PR TITLE
[BE/feat/#150] 게시물, 댓글 삭제 API 구현

### DIFF
--- a/backend/src/main/java/com/rising/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/controller/CommentController.java
@@ -34,4 +34,10 @@ public class CommentController {
         List<CommentDto.CommentListResponse> comments = commentService.findByPostId(postId);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_CREATE_SUCCESS, comments));
     }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ResultResponse> delete(@RequestParam Long commentId) {
+        commentService.deleteCommentById(commentId);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_CREATE_SUCCESS));
+    }
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/controller/CommentController.java
@@ -30,13 +30,13 @@ public class CommentController {
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<ResultResponse> getComments(@RequestParam Long postId) {
+    public ResponseEntity<ResultResponse> getComments(@PathVariable Long postId) {
         List<CommentDto.CommentListResponse> comments = commentService.findByPostId(postId);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_CREATE_SUCCESS, comments));
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_GET_SUCCESS, comments));
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<ResultResponse> delete(@RequestParam Long commentId) {
+    public ResponseEntity<ResultResponse> delete(@PathVariable Long commentId) {
         commentService.deleteCommentById(commentId);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_CREATE_SUCCESS));
     }

--- a/backend/src/main/java/com/rising/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/controller/CommentController.java
@@ -38,6 +38,6 @@ public class CommentController {
     @DeleteMapping("/{commentId}")
     public ResponseEntity<ResultResponse> delete(@PathVariable Long commentId) {
         commentService.deleteCommentById(commentId);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_CREATE_SUCCESS));
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_DELETE_SUCCESS));
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/domain/Comment.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/domain/Comment.java
@@ -36,6 +36,4 @@ public class Comment extends BaseEntity {
     private User user;
 
     private Long parentId;
-
-
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/domain/Comment.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/domain/Comment.java
@@ -12,8 +12,8 @@ import javax.validation.constraints.NotBlank;
 
 @Getter
 @Entity
-@Where(clause = "is_deleted IS FALSE")
-@SQLDelete(sql = "UPDATE comment SET is_deleted = TRUE where id = ?")
+@Where(clause = "is_deleted=false")
+@SQLDelete(sql = "UPDATE comment SET is_deleted = true WHERE id=?")
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/rising/backend/domain/comment/domain/Comment.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/domain/Comment.java
@@ -4,12 +4,16 @@ import com.rising.backend.domain.post.domain.Post;
 import com.rising.backend.domain.user.domain.User;
 import com.rising.backend.global.domain.BaseEntity;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 
 @Getter
 @Entity
+@Where(clause = "is_deleted IS FALSE")
+@SQLDelete(sql = "UPDATE comment SET is_deleted = TRUE where id = ?")
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -32,5 +36,6 @@ public class Comment extends BaseEntity {
     private User user;
 
     private Long parentId;
+
 
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/repository/CommentRepository.java
@@ -17,6 +17,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByParentId(Long parentId);
 
+    void deleteAllByParentId(Long parentId);
+
     Long countByPost_Id(Long postId);
 
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/service/CommentService.java
@@ -21,6 +21,10 @@ public class CommentService {
         return commentRepository.save(entity);
     }
 
+    public Comment findByCommentId(Long commentId) {
+        return commentRepository.findById(commentId).orElseThrow();
+    }
+
     public List<CommentDto.CommentListResponse> findByPostId(Long postId) {
         List<Comment> comments = commentRepository.findCommentsByPostId(postId);
         return comments.stream().map(c -> commentMapper.toCommentDto(c, findChildrenByParentId(c.getId())))
@@ -31,5 +35,13 @@ public class CommentService {
         List<Comment> comments = commentRepository.findByParentId(parentId);
         return comments.stream().map(c -> commentMapper.toCommentDto(c, null))
                 .collect(Collectors.toList());
+    }
+
+    public void deleteCommentById(Long commentId) {
+        List<Comment> comments = commentRepository.findByParentId(commentId);
+        if (comments != null) {
+            commentRepository.deleteAllByParentId(commentId);
+        }
+        commentRepository.deleteById(commentId);
     }
 }

--- a/backend/src/main/java/com/rising/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/rising/backend/domain/comment/service/CommentService.java
@@ -40,7 +40,9 @@ public class CommentService {
     public void deleteCommentById(Long commentId) {
         List<Comment> comments = commentRepository.findByParentId(commentId);
         if (comments != null) {
-            commentRepository.deleteAllByParentId(commentId);
+            for (Comment comment : comments) {
+                commentRepository.deleteById(comment.getId());
+            }
         }
         commentRepository.deleteById(commentId);
     }

--- a/backend/src/main/java/com/rising/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/controller/PostController.java
@@ -69,9 +69,17 @@ public class PostController {
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POST_FIND_SUCCESS, post));
     }
 
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ResultResponse> delete(@PathVariable Long postId) {
+        postService.deletePostById(postId);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.POST_DELETE_SUCCESS));
+    }
+
     @GetMapping("/mypages/{userId}")
     public ResponseEntity<ResultResponse> getPostListByUserId(@PathVariable Long userId) {
         List<PostDto.PostGetListResponse> postList = postService.getPostListByUserId(userId);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POSTLIST_FIND_BY_USERID_SUCCESS, postList));
     }
+
+
 }

--- a/backend/src/main/java/com/rising/backend/domain/post/domain/Post.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/domain/Post.java
@@ -3,6 +3,8 @@ package com.rising.backend.domain.post.domain;
 import com.rising.backend.domain.user.domain.User;
 import com.rising.backend.global.domain.BaseEntity;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
@@ -12,6 +14,8 @@ import java.util.List;
 
 @Getter
 @Entity
+@Where(clause = "is_deleted=false")
+@SQLDelete(sql = "UPDATE post SET is_deleted = true WHERE id=?")
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/rising/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/rising/backend/domain/post/service/PostService.java
@@ -59,7 +59,6 @@ public class PostService {
         return post.getSessionUrl();
     }
 
-
     public PostDto.PostDetailResponse getPostDtoById(Long postId) {
         Post post = findPostById(postId);
         List<String> tags = postMapper.TagtoString(post.getTag());
@@ -75,4 +74,7 @@ public class PostService {
         return tagRepository.findByContent(content);
     }
 
+    public void deletePostById(Long postId) {
+        postRepository.deleteById(postId);
+    }
 }

--- a/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
+++ b/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
@@ -14,6 +14,8 @@ public enum ResultCode {
 
     //POST
     POST_CREATE_SUCCESS(201, "게시글 등록 성공"),
+
+    POST_DELETE_SUCCESS(200, "게시글 삭제 성공"),
     POST_PAGINATION_SUCCESS(200, "게시글 리스트 조회 성공"),
     POST_FIND_SUCCESS(200, "게시글 id로 단일 게시글 조회 성공"),
     POSTLIST_FIND_BY_USERID_SUCCESS(200, "유저 id로 게시글 리스트 조회 성공"),

--- a/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
+++ b/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
@@ -26,6 +26,8 @@ public enum ResultCode {
     //COMMENT
     COMMENT_CREATE_SUCCESS(201, "댓글 등록 성공"),
     COMMENT_GET_SUCCESS(200, "댓글 조회 성공"),
+    COMMENT_DELETE_SUCCESS(200, "댓글 삭제 성공"),
+
 
     //CHATROOM
     CHATROOM_CREATE_SUCCESS(201, "채팅방 생성 성공"),


### PR DESCRIPTION
## 🛠️ 변경사항
- 각 comment, post 엔티티 파일에 다음을 추가
@Where(clause = "is_deleted=false") 
-> 조회 시 따로 처리 필요 없이 삭제하지 않은 데이터만 조회 가능
@SQLDelete(sql = "UPDATE comment SET is_deleted = true WHERE id=?") 
-> jparepository를 이용해 delete를 실행 시, 원하는 컬럼(is_deleted)의 값을 true로 업데이트


</br>
</br>

## ☝️ 유의사항

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
