### PR TITLE
[BE/feat/#156] 유저, 채팅방 soft delete로 변경

### DIFF
--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
@@ -64,4 +64,10 @@ public class ChatRoomController {
         return ResponseEntity.ok(ResultResponse.of(ResultCode.CHATROOM_FIND_BY_MENTOR, mentorChatRoom));
     }
 
+    @LoginRequired
+    @DeleteMapping("/{id}")
+    public void deleteChatRoom (@PathVariable Long id) {
+        chatRoomService.deleteChatRoom(id);
+    }
+
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/controller/ChatRoomController.java
@@ -8,6 +8,7 @@ import com.rising.backend.global.annotation.LoginRequired;
 import com.rising.backend.global.annotation.LoginUser;
 import com.rising.backend.global.result.ResultCode;
 import com.rising.backend.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -64,10 +65,12 @@ public class ChatRoomController {
         return ResponseEntity.ok(ResultResponse.of(ResultCode.CHATROOM_FIND_BY_MENTOR, mentorChatRoom));
     }
 
+    @Operation(summary = "채팅방 삭제", description = "채팅방 id로 채팅방 soft delete")
+    @DeleteMapping("/{chatRoomId}")
     @LoginRequired
-    @DeleteMapping("/{id}")
-    public void deleteChatRoom (@PathVariable Long id) {
-        chatRoomService.deleteChatRoom(id);
+    public ResponseEntity<ResultResponse> deleteChatRoom(@PathVariable Long chatRoomId) {
+        chatRoomService.deleteChatRoom(chatRoomId);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.CHATROOM_DELETE_SUCCESS));
     }
 
 }

--- a/backend/src/main/java/com/rising/backend/domain/chat/domain/ChatRoom.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/domain/ChatRoom.java
@@ -4,6 +4,8 @@ import com.rising.backend.domain.post.domain.Post;
 import com.rising.backend.domain.user.domain.User;
 import com.rising.backend.global.domain.BaseEntity;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -12,6 +14,8 @@ import javax.persistence.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE chat_room SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class ChatRoom extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/rising/backend/domain/chat/service/ChatRoomService.java
@@ -63,4 +63,8 @@ public class ChatRoomService {
         return Objects.equals(postUserId, userId);
     }
 
+    public void deleteChatRoom(Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 없습니다. id=" + chatRoomId));
+        chatRoomRepository.delete(chatRoom);
+    }
 }

--- a/backend/src/main/java/com/rising/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/controller/UserController.java
@@ -76,6 +76,12 @@ public class UserController {
         return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_FIND_INFO_SUCCESS,userService.getUserInfo(user)));
     }
 
+    @DeleteMapping()
+    @LoginRequired
+    public void deleteUser(@LoginUser User user) {
+        userService.deleteUser(user);
+    }
+
 
 
 }

--- a/backend/src/main/java/com/rising/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/controller/UserController.java
@@ -9,6 +9,8 @@ import com.rising.backend.global.annotation.LoginRequired;
 import com.rising.backend.global.annotation.LoginUser;
 import com.rising.backend.global.result.ResultCode;
 import com.rising.backend.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -75,13 +77,11 @@ public class UserController {
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_FIND_INFO_SUCCESS,userService.getUserInfo(user)));
     }
-
+    @Operation(summary = "회원 삭제", description = "현재 로그인된 user 정보 soft delete")
     @DeleteMapping()
     @LoginRequired
-    public void deleteUser(@LoginUser User user) {
+    public ResponseEntity<ResultResponse> deleteUser(@LoginUser User user) {
         userService.deleteUser(user);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_DELETE_SUCCESS));
     }
-
-
-
 }

--- a/backend/src/main/java/com/rising/backend/domain/user/domain/User.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/domain/User.java
@@ -2,6 +2,8 @@ package com.rising.backend.domain.user.domain;
 
 import com.rising.backend.global.domain.BaseEntity;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
@@ -11,6 +13,8 @@ import javax.validation.constraints.NotBlank;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE user SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class User extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/com/rising/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/rising/backend/domain/user/service/UserService.java
@@ -38,4 +38,8 @@ public class UserService {
     public UserDto.UserInfoResponse getUserInfo(User user) {
         return userMapper.toUserInfoDto(user);
     }
+
+    public void deleteUser(User user) {
+        userRepository.delete(user);
+    }
 }

--- a/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
+++ b/backend/src/main/java/com/rising/backend/global/result/ResultCode.java
@@ -11,6 +11,8 @@ public enum ResultCode {
     USER_NOT_LOGIN(201, "로그인 필요"),
     USER_LOGIN_SUCCESS(200, "로그인 성공"),
     USER_FIND_INFO_SUCCESS(200, "유저 정보 조회 성공"),
+    USER_DELETE_SUCCESS(200, "유저 삭제 성공"),
+
 
     //POST
     POST_CREATE_SUCCESS(201, "게시글 등록 성공"),
@@ -31,8 +33,7 @@ public enum ResultCode {
     CHATROOM_CREATE_SUCCESS(201, "채팅방 생성 성공"),
     CHATROOM_FIND_BY_MENTEE(200, "로그인된 유저가 멘티인 채팅방 조회 성공"),
     CHATROOM_FIND_BY_MENTOR(200, "로그인된 유저가 멘토인 채팅방 조회 성공"),
-
-
+    CHATROOM_DELETE_SUCCESS(200, "채팅방 삭제 성공"),
 
     //CHATMESSAGE
     CHATMESSAGE_FIND_SUCCESS(200, "채팅 메시지 반환 성공");


### PR DESCRIPTION
## 🛠️ 변경사항
- 유저 및 채팅방 삭제 api 호출시 soft delete되도록 변경
- 조회시 is_deleted가 false인 것들만 필터링

</br>
</br>

## ☝️ 유의사항

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
